### PR TITLE
Attempt to change fixed buffer

### DIFF
--- a/pysam/libcalignedsegment.pxd
+++ b/pysam/libcalignedsegment.pxd
@@ -72,6 +72,7 @@ cdef class PileupColumn:
     cdef uint32_t min_base_quality
     cdef uint8_t * buf
     cdef char * reference_sequence
+    cdef int max_depth
 
 cdef class PileupRead:
     cdef int32_t  _qpos
@@ -95,7 +96,8 @@ cdef PileupColumn makePileupColumn(
     int n_pu,
     uint32_t min_base_quality,
     char * reference_sequence,
-    AlignmentHeader header)
+    AlignmentHeader header, 
+    int max_depth)
 
 cdef PileupRead makePileupRead(bam_pileup1_t * src,
 		               AlignmentHeader header)

--- a/pysam/libcalignmentfile.pxd
+++ b/pysam/libcalignmentfile.pxd
@@ -63,6 +63,7 @@ cdef class PileupColumn:
     cdef int tid
     cdef int pos
     cdef int n_pu
+    cdef int max_depth
 
 
 cdef class PileupRead:


### PR DESCRIPTION
The buffer size for pileup output was fixed; this is an attempt to make it reflective of the max_depth option invoked when creating the pileup.